### PR TITLE
Use dash instead of underscore in URL

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,7 @@ const { createFilePath } = require(`gatsby-source-filesystem`)
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
   if (node.internal.type === `PeopleYaml`) {
-    const slug = `/people/${node.name}_${node.lastname}`
+    const slug = `/people/${node.name}-${node.lastname}`
     createNodeField({
       node,
       name: `slug`,


### PR DESCRIPTION
To quote #34, Google recommends using dashes instead of underscores for better searches.