### PR TITLE
Styling quote section in People page

### DIFF
--- a/src/templates/people-template.js
+++ b/src/templates/people-template.js
@@ -195,7 +195,7 @@ const PeoplePage = ({ data: { peopleYaml } }) => (
                 marginRight: "1.6rem",
               }}
             >
-              "
+              “
             </div>
             <blockquote>{peopleYaml.quotes}</blockquote>
           </div>

--- a/src/templates/people-template.js
+++ b/src/templates/people-template.js
@@ -57,7 +57,11 @@ const cssSectionBlack = {
   },
   blockquote: {
     color: "var(--cl-white)",
-    lineHeight: 1.5,
+    lineHeight: 1.8,
+    border: "none",
+    fontSize: "3.6rem",
+    fontStyle: "normal",
+    fontFamily: "var(--ff-title)",
   },
 }
 
@@ -175,16 +179,52 @@ const PeoplePage = ({ data: { peopleYaml } }) => (
       <section
         css={{
           ...cssSectionBlack,
+          paddingTop: "6.4rem",
+          paddingBottom: "5.2rem",
         }}
       >
-        <div className="container">
-          <span css={{ color: "#fcbbdd", fontSize: "3.6rem" }}>"</span>
-          <blockquote css={{ fontSize: "3.6rem" }}>
-            {peopleYaml.quotes}
-          </blockquote>
-          <div className="quotes-reference">
-            — {`${peopleYaml.title} ${peopleYaml.name} ${peopleYaml.lastname}`}(
-            <ExternalLink href={peopleYaml.quotes_url}>อ้างอิง</ExternalLink>)
+        <div
+          className="container"
+          css={{ display: "flex", flexDirection: "column" }}
+        >
+          <div css={{ display: "flex", marginBottom: "3.6rem" }}>
+            <div
+              css={{
+                fontSize: "4.8rem",
+                fontFamily: "var(--ff-title)",
+                marginRight: "1.6rem",
+              }}
+            >
+              "
+            </div>
+            <blockquote>{peopleYaml.quotes}</blockquote>
+          </div>
+          <div
+            css={{
+              display: "flex",
+              justifyContent: "flex-end",
+              fontFamily: "var(--ff-title)",
+              fontSize: "3.6rem",
+            }}
+          >
+            <div css={{ marginRight: "2rem" }}>—</div>
+            <div>
+              <div css={{ marginBottom: "0.5rem" }}>
+                {`${peopleYaml.title} ${peopleYaml.name} ${peopleYaml.lastname}`}
+              </div>
+              <div>
+                <ExternalLink
+                  href={peopleYaml.quotes_url}
+                  css={{
+                    textDecoration: "underline",
+                    fontSize: "2.4rem",
+                    color: "white",
+                  }}
+                >
+                  อ้างอิง
+                </ExternalLink>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/src/templates/people-template.js
+++ b/src/templates/people-template.js
@@ -183,10 +183,7 @@ const PeoplePage = ({ data: { peopleYaml } }) => (
           paddingBottom: "5.2rem",
         }}
       >
-        <div
-          className="container"
-          css={{ display: "flex", flexDirection: "column" }}
-        >
+        <div className="container">
           <div css={{ display: "flex", marginBottom: "3.6rem" }}>
             <div
               css={{


### PR DESCRIPTION
For #40.

### Screenshot
<img width="1440" alt="Screen Shot 2019-11-01 at 2 02 28 AM" src="https://user-images.githubusercontent.com/6439183/67977974-aa372c00-fc4b-11e9-9bd8-a347295de135.png">


### What I have compromised in design
- The available font weight does not seem to match the design
- The big double quote sign in the front (currently using font's `“`)
- Long line in front of quote reference

Please let me know if you need any adjustments for this change. Cheers :)



