### PR TITLE
Display contributor list by fetching from GitHub API

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,7 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
 const path = require(`path`)
-
+const axios = require(`axios`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
 // You can delete this file if you're not using it
@@ -109,5 +109,32 @@ exports.createPages = async ({ graphql, actions }) => {
         slug: node.fields.slug,
       },
     })
+  })
+}
+
+exports.sourceNodes = async ({
+  actions,
+  createNodeId,
+  createContentDigest,
+}) => {
+  const { createNode } = actions
+
+  // Contributors
+  const { data } = await axios.get(
+    `https://api.github.com/repos/codeforthailand/politician-directory/contributors`
+  )
+
+  data.forEach(contributor => {
+    const meta = {
+      id: createNodeId(`contributor-${contributor.id}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: `Contributor`,
+        contentDigest: createContentDigest(contributor),
+      },
+    }
+    const node = Object.assign({}, contributor, meta)
+    createNode(node)
   })
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
+    "axios": "^0.19.0",
     "gatsby": "^2.15.29",
     "gatsby-image": "^2.2.24",
     "gatsby-plugin-emotion": "^4.1.12",

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -3,6 +3,7 @@ import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import ExternalLink from "../components/externalLink"
+import { graphql } from "gatsby"
 
 const h2 = {
   fontSize: "2rem",
@@ -11,7 +12,20 @@ const sectionContent = {
   marginBottom: "3rem",
 }
 
-const AboutPage = () => (
+export const query = graphql`
+  query {
+    allContributor {
+      edges {
+        node {
+          login
+          html_url
+        }
+      }
+    }
+  }
+`
+
+const AboutPage = ({ data }) => (
   <Layout>
     <SEO title="About Us" />
     <section>
@@ -41,18 +55,12 @@ const AboutPage = () => (
             <strong>เขียนโปรแกรม 💻</strong>
           </div>
           <div>
-            <ExternalLink href="https://github.com/rapee">
-              Rapee Suveeranont
-            </ExternalLink>{" "}
-            <ExternalLink href="https://github.com/Nakanan">
-              TEnsor4
-            </ExternalLink>{" "}
-            <ExternalLink href="https://th1nkk1d.xyz">
-              Withee Poositasai
-            </ExternalLink>{" "}
-            <ExternalLink href="https://github.com/noimeta">
-              Noi Meta 😼
-            </ExternalLink>
+            {data.allContributor.edges.map(({ node }, i) => (
+              <span>
+                {i === 0 ? "" : " "}
+                <ExternalLink href={node.html_url}>{node.login}</ExternalLink>
+              </span>
+            ))}
           </div>
 
           <div>


### PR DESCRIPTION
For #50.

# Changes
- [x] Fetching contributor list of this repo using GitHub REST API v3
- [x] Populating the list in build-time
- [x] Applying the list to About page
- [ ] More styling?

# Screenshot
<img width="787" alt="Screen Shot 2019-11-02 at 10 04 37 PM" src="https://user-images.githubusercontent.com/6439183/68072846-d1613b00-fdbc-11e9-9838-b16f7f3e8311.png">


