### PR TITLE
Add gatsby clean when run develop script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "ELECT <iiieyes@gmail.com>",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby clean && gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
Since we found build error so many time when `run dev` and the problem can be fix with `gatsby clean`, so I add `gatsby clean` before `gatsby develop` when the dev script was called.

*This PR was created from changes picked up from PR #77 which the main issue was included in PR #67. Then should we close PR #77 ?

Note that other changes were solved.