### PR TITLE
Suport VoteLogCard in Mobile (and some related fixes)

### DIFF
--- a/src/components/voteLogCard.js
+++ b/src/components/voteLogCard.js
@@ -48,7 +48,7 @@ const VoteLogCard = ({
           style={{
             width: `calc(${approveBar} - 0.6667px)`,
             height: "100%",
-            backgroundColor: "green",
+            backgroundColor: "var(--cl-vote-yes)",
             borderRight: "1px solid var(--cl-black)",
           }}
         />
@@ -56,7 +56,7 @@ const VoteLogCard = ({
           style={{
             width: `calc(${disproveBar} - 0.6667px)`,
             height: "100%",
-            backgroundColor: "#404040",
+            backgroundColor: "var(--cl-vote-no)",
             borderRight: "1px solid var(--cl-black)",
           }}
         />
@@ -64,7 +64,7 @@ const VoteLogCard = ({
           style={{
             width: `calc(${abstainedBar} - 0.6667px)`,
             height: "100%",
-            backgroundColor: "lightgray",
+            backgroundColor: "var(--cl-vote-abstained)",
           }}
         />
       </div>

--- a/src/components/voteLogCard.js
+++ b/src/components/voteLogCard.js
@@ -39,32 +39,34 @@ const VoteLogCard = ({
           width: "100%",
           height: "1.5rem",
           border: "1px solid var(--cl-black)",
-          boxSizing: "unset",
           display: "flex",
           flexWrap: "nowrap",
         }}
       >
         <div
           style={{
-            width: `calc(${approveBar} - 0.6667px)`,
+            width: approveBar,
             height: "100%",
             backgroundColor: "var(--cl-vote-yes)",
             borderRight: "1px solid var(--cl-black)",
+            boxSizing: "unset",
           }}
         />
         <div
           style={{
-            width: `calc(${disproveBar} - 0.6667px)`,
+            width: disproveBar,
             height: "100%",
             backgroundColor: "var(--cl-vote-no)",
             borderRight: "1px solid var(--cl-black)",
+            boxSizing: "unset",
           }}
         />
         <div
           style={{
-            width: `calc(${abstainedBar} - 0.6667px)`,
+            width: abstainedBar,
             height: "100%",
             backgroundColor: "var(--cl-vote-abstained)",
+            boxSizing: "unset",
           }}
         />
       </div>

--- a/src/components/voteLogCard.js
+++ b/src/components/voteLogCard.js
@@ -38,33 +38,33 @@ const VoteLogCard = ({
         style={{
           width: "100%",
           height: "1.5rem",
+          border: "1px solid var(--cl-black)",
+          boxSizing: "unset",
+          display: "flex",
+          flexWrap: "nowrap",
         }}
       >
         <div
           style={{
-            width: approveBar,
+            width: `calc(${approveBar} - 0.6667px)`,
             height: "100%",
             backgroundColor: "green",
-            display: "inline-block",
-            border: "1px solid var(--cl-black)",
+            borderRight: "1px solid var(--cl-black)",
           }}
         />
         <div
           style={{
-            width: disproveBar,
+            width: `calc(${disproveBar} - 0.6667px)`,
             height: "100%",
             backgroundColor: "#404040",
-            display: "inline-block",
-            border: "1px solid var(--cl-black)",
+            borderRight: "1px solid var(--cl-black)",
           }}
         />
         <div
           style={{
-            width: abstainedBar,
+            width: `calc(${abstainedBar} - 0.6667px)`,
             height: "100%",
             backgroundColor: "lightgray",
-            display: "inline-block",
-            border: "1px solid var(--cl-black)",
           }}
         />
       </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -271,7 +271,7 @@ const IndexPage = ({ data }) => {
           <div
             css={{
               display: "flex",
-              justifyContent: "flex-start",
+              justifyContent: "center",
               alignItems: "flex-start",
               flexWrap: "wrap",
               marginTop: "6rem",
@@ -281,11 +281,8 @@ const IndexPage = ({ data }) => {
               <VoteLogCard
                 key={node.id}
                 css={{
-                  width: `calc(${100 / 2}% - 2rem)`,
-                  marginBottom: "2rem",
-                  "&:nth-of-type(2n+1)": {
-                    marginRight: "2rem",
-                  },
+                  width: `calc((var(--container-width) - 4rem) / 2)`,
+                  margin: "0 1rem 2rem 1rem",
                 }}
                 legal_title={node.legal_title}
                 legal_title_en={node.en.legal_title}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,8 @@
   --cl-vote-abstained: #cccccc;
   --cl-vote-yes: #329a2e;
   --cl-vote-no: #ec2627;
+
+  --container-width: 920px;
 }
 
 a {
@@ -31,6 +33,6 @@ a:hover {
 }
 
 .container {
-  max-width: 920px;
+  max-width: var(--container-width);
   margin: 0 auto;
 }

--- a/src/templates/votelog-list-template.js
+++ b/src/templates/votelog-list-template.js
@@ -141,7 +141,7 @@ const VoteLogPage = ({
           <div
             css={{
               display: "flex",
-              justifyContent: "flex-start",
+              justifyContent: "center",
               alignItems: "flex-start",
               flexWrap: "wrap",
               marginTop: "6rem",
@@ -151,11 +151,8 @@ const VoteLogPage = ({
               <VoteLogCard
                 key={node.id}
                 css={{
-                  width: `calc(${100 / 2}% - 2rem)`,
-                  marginBottom: "2rem",
-                  "&:nth-child(2n+1)": {
-                    marginRight: "2rem",
-                  },
+                  width: `calc((var(--container-width) - 4rem) / 2)`,
+                  margin: "0 1rem 2rem 1rem",
                   border: "2px solid var(--cl-black)",
                 }}
                 legal_title={node.legal_title}


### PR DESCRIPTION
This pull request is for #87 

## Changes
- Extract `.container`'s width as a variable, and use it to calculate width of `VoteLogCard`
- Fix vote proportion bar (top element in `VoteLogCard`) overflowing caused by borders' of zero-width child. -> I tried my best to make these bars still represent its proportions accurately.
- I took the liberty to change vote proportion bar's colors to match the design. If this is not what you intent, I separate the commit for the possible revert.

## Screenshot
#### Mobile
![Screenshot_2019-11-11 Home](https://user-images.githubusercontent.com/6439183/68561230-3aa91400-0477-11ea-89db-8683098188e5.png)
#### Desktop
![Screenshot_2019-11-11 Home(1)](https://user-images.githubusercontent.com/6439183/68561231-3aa91400-0477-11ea-8907-eb417ffb9a1b.png)
#### w/ Color Change
<img width="457" alt="Screen Shot 2019-11-11 at 11 38 23 AM" src="https://user-images.githubusercontent.com/6439183/68561370-dc306580-0477-11ea-8815-6b186fec9b25.png">

-------
Thanks!