### PR TITLE
Fix slugs for people and their images

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,7 @@ const { createFilePath } = require(`gatsby-source-filesystem`)
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
   if (node.internal.type === `PeopleYaml`) {
-    const slug = `/people/${node.name}-${node.lastname}`
+    const slug = `/people/${node.name}-${node.lastname.replace(/ /g, '-')}`
     createNodeField({
       node,
       name: `slug`,

--- a/src/components/cabinetMemberSection/index.js
+++ b/src/components/cabinetMemberSection/index.js
@@ -18,6 +18,9 @@ const CabinetMemberSection = () => {
             party
             party_group
             mp_type
+            fields {
+              slug
+            }
           }
         }
       }

--- a/src/components/peopleCard.js
+++ b/src/components/peopleCard.js
@@ -114,7 +114,7 @@ const PeopleCard = ({ type, ...props }) => {
 
   return (
     <Link
-      to={`/people/${props.name}-${props.lastname}`}
+      to={props.fields.slug}
       key={props.id}
       css={{
         display: "flex",

--- a/src/components/peopleCardMini.js
+++ b/src/components/peopleCardMini.js
@@ -14,9 +14,7 @@ const MPInfo = props => (
       height: "100%",
     }}
   >
-    <Link to={`/people/${props.name}-${props.lastname}`}>
-      {`${props.name} ${props.lastname}`}
-    </Link>
+    <Link to={props.fields.slug}>{`${props.name} ${props.lastname}`}</Link>
   </div>
 )
 
@@ -38,7 +36,7 @@ const PeopleCardMini = props => {
         {props.position}
       </div>
       <div>
-        <Link to={`/people/${props.name}-${props.lastname}`}>
+        <Link to={props.fields.slug}>
           <div
             css={{
               borderRadius: 84,

--- a/src/pages/representatives.js
+++ b/src/pages/representatives.js
@@ -182,7 +182,7 @@ const RepresentativesPage = props => {
       },
     ].map((keyPos, id) => {
       if (!house[keyPos.name]) return null
-      const nameParts = house[keyPos.name].split(" ").slice(1)
+      const nameParts = house[keyPos.name].split(" ")
       const slug = peopleSlug(nameParts.join(" "))
       const name = nameParts[0]
       const lastname = nameParts.slice(1).join(" ")

--- a/src/pages/representatives.js
+++ b/src/pages/representatives.js
@@ -4,7 +4,7 @@ import _ from "lodash"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { loadCategoryStats, joinPeopleVotelog } from "../utils"
+import { loadCategoryStats, joinPeopleVotelog, peopleSlug } from "../utils"
 import StackedBarChart from "../components/stackedBarChart"
 import { OfficialWebsite, InOfficeDate } from "../components/profile"
 import PeopleCardMini from "../components/peopleCardMini"
@@ -182,9 +182,12 @@ const RepresentativesPage = props => {
       },
     ].map((keyPos, id) => {
       if (!house[keyPos.name]) return null
-      const [name, lastname] = house[keyPos.name].split(" ")
+      const nameParts = house[keyPos.name].split(" ").slice(1)
+      const slug = peopleSlug(nameParts.join(" "))
+      const name = nameParts[0]
+      const lastname = nameParts.slice(1).join(" ")
       const position = keyPos.label
-      return { id, name, lastname, position }
+      return { id, name, lastname, position, fields: { slug } }
     })
   )
 

--- a/src/pages/senate.js
+++ b/src/pages/senate.js
@@ -4,7 +4,7 @@ import _ from "lodash"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { loadCategoryStats, joinPeopleVotelog } from "../utils"
+import { loadCategoryStats, joinPeopleVotelog, peopleSlug } from "../utils"
 import StackedBarChart from "../components/stackedBarChart"
 import { OfficialWebsite, InOfficeDate } from "../components/profile"
 import PeopleCardMini from "../components/peopleCardMini"
@@ -237,9 +237,12 @@ const SenatePage = props => {
       },
     ].map((keyPos, id) => {
       if (!senate[keyPos.name]) return null
-      const [name, lastname] = senate[keyPos.name].split(" ")
+      const nameParts = senate[keyPos.name].split(" ").slice(1)
+      const slug = peopleSlug(nameParts.join(" "))
+      const name = nameParts[0]
+      const lastname = nameParts.slice(1).join(" ")
       const position = keyPos.label
-      return { id, name, lastname, position }
+      return { id, name, lastname, position, fields: { slug } }
     })
   )
 

--- a/src/pages/senate.js
+++ b/src/pages/senate.js
@@ -237,7 +237,7 @@ const SenatePage = props => {
       },
     ].map((keyPos, id) => {
       if (!senate[keyPos.name]) return null
-      const nameParts = senate[keyPos.name].split(" ").slice(1)
+      const nameParts = senate[keyPos.name].split(" ")
       const slug = peopleSlug(nameParts.join(" "))
       const name = nameParts[0]
       const lastname = nameParts.slice(1).join(" ")

--- a/src/templates/party-template.js
+++ b/src/templates/party-template.js
@@ -4,7 +4,7 @@ import _ from "lodash"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { loadCategoryStats, joinPeopleVotelog } from "../utils"
+import { loadCategoryStats, joinPeopleVotelog, peopleSlug } from "../utils"
 import StackedBarChart from "../components/stackedBarChart"
 import { OfficialWebsite, InOfficeDate } from "../components/profile"
 import PeopleCardMini from "../components/peopleCardMini"
@@ -287,9 +287,12 @@ const PartyPage = props => {
       },
     ].map((keyPos, id) => {
       if (!party[keyPos.name]) return null
-      const [name, lastname] = party[keyPos.name].split(" ").slice(-2)
+      const nameParts = party[keyPos.name].split(" ").slice(1)
+      const slug = peopleSlug(nameParts.join(" "))
+      const name = nameParts[0]
+      const lastname = nameParts.slice(1).join(" ")
       const position = keyPos.label
-      return { id, name, lastname, position }
+      return { id, name, lastname, position, fields: { slug } }
     })
   )
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -29,12 +29,23 @@ export function sortThaiLocale(a, b) {
 }
 
 /**
+ * Create people profile slug
+ * @param {String} fullname
+ */
+export function peopleSlug(fullname) {
+  if (!fullname) return ""
+  return `/people/${fullname.replace(/ /g, "-")}`
+}
+
+/**
  * Create poltician profile image URL
  * @param {People} profile
  */
 export function politicianPicture(profile) {
   if (!profile.name || !profile.lastname) return ""
-  return `https://elect.thematter.co/data/politicians/${profile.name}-${profile.lastname}.jpg`
+  return `https://elect.thematter.co/data/politicians/${
+    profile.name
+  }-${profile.lastname.replace(/ /g, "-")}.jpg`
 }
 /**
  * Create poltician profile image URL


### PR DESCRIPTION
## Reason
- Key members of parties, MPs, senates, who have space (` `) in their last name are not represented correctly in `<PeopleCardMini>`.
- Profile picture for this group of people displays 404.

## Change
- Use `People.fields.slug` in every links
- Generate correct link for profile picture
- Create utility function for getting slug without `People` (for `representative`, `senate`, `party` pages)
- Create people nodes with slug that uses dash (`-`) for every space (` `).  E.g. `/people/วัชรา-ณ วังขนาย` to `/people/วัชรา-ณ-วังขนาย`

## Further Discussion
Key members of parties in `party.yaml` are not in a consistent form.

No title: `speaker: ชวน หลีกภัย`
With title: `prime_minister: พลเอก ประยุทธ์ จันทร์โอชา`, `party_leader: นาย ปรีดา บุญเพลิง`

This makes getting slug from their name challenging. And might be difficult when we have `speaker: พลเอก ประยุทธ์ จันทร์โอชา`.

We may consider either dropping all titles, storing all titles, or using different approaches getting slugs for these pages.


  