### PR TITLE
Support Twitter sharing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,7 @@ const config = {
     title: `They Work For Us`,
     description: `ใครเป็นใคร เคยทำอะไรมาบ้าง ตอนนี้อยู่ตำแหน่งไหน และยกมือสนับสนุนอะไรในสภา`,
     author: `@electinth`,
+    baseUrl: process.env.BASE_URL || "",
   },
   pathPrefix: process.env.BASE_PATH || "/",
   plugins: [

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -27,6 +27,10 @@ function SEO({ description, lang, meta, title, imageUrl }) {
 
   const metaDescription = description || site.siteMetadata.description
   const metaImageUrl = imageUrl || "/seo/share/default.png"
+  const sharableTitle =
+    title === "Home"
+      ? `${site.siteMetadata.title} รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา`
+      : title
 
   return (
     <Helmet
@@ -45,10 +49,7 @@ function SEO({ description, lang, meta, title, imageUrl }) {
         },
         {
           property: `og:title`,
-          content:
-            title === "Home"
-              ? `${site.siteMetadata.title} รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา`
-              : title,
+          content: sharableTitle,
         },
         {
           property: `og:description`,
@@ -86,10 +87,7 @@ function SEO({ description, lang, meta, title, imageUrl }) {
         },
         {
           name: `twitter:title`,
-          content:
-            title === "Home"
-              ? `${site.siteMetadata.title} รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา`
-              : title,
+          content: sharableTitle,
         },
         {
           name: `twitter:description`,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -72,7 +72,13 @@ function SEO({ description, lang, meta, title, imageUrl }) {
         },
         {
           name: `twitter:card`,
-          content: `summary`,
+          content: `summary_large_image`,
+        },
+        {
+          name: `twitter:image`,
+          content: metaImageUrl.includes("http")
+            ? metaImageUrl
+            : `https://theyworkforus.elect.in.th${metaImageUrl}`,
         },
         {
           name: `twitter:creator`,
@@ -80,7 +86,10 @@ function SEO({ description, lang, meta, title, imageUrl }) {
         },
         {
           name: `twitter:title`,
-          content: title,
+          content:
+            title === "Home"
+              ? `${site.siteMetadata.title} รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา`
+              : title,
         },
         {
           name: `twitter:description`,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -19,6 +19,7 @@ function SEO({ description, lang, meta, title, imageUrl }) {
             title
             description
             author
+            baseUrl
           }
         }
       }
@@ -79,7 +80,7 @@ function SEO({ description, lang, meta, title, imageUrl }) {
           name: `twitter:image`,
           content: metaImageUrl.includes("http")
             ? metaImageUrl
-            : `https://theyworkforus.elect.in.th${metaImageUrl}`,
+            : `${site.siteMetadata.baseUrl}${metaImageUrl}`,
         },
         {
           name: `twitter:creator`,


### PR DESCRIPTION
Related to #107 

This PR adds Twitter sharing to the site.

Because Twitter requires full URL for `twitter:image`, I use our production URL for now. Perhaps there is a better solution for this.

## Screenshot
<img width="449" alt="Screen Shot 2019-11-26 at 2 32 15 AM" src="https://user-images.githubusercontent.com/6439183/69572084-f597ec80-0ff5-11ea-9a2a-0d5bab4c6b3f.png">
<img width="461" alt="Screen Shot 2019-11-26 at 2 32 01 AM" src="https://user-images.githubusercontent.com/6439183/69572082-f597ec80-0ff5-11ea-99bc-180ed66a9db6.png">


