### PR TITLE
Some UI updates according to feedback

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -60,7 +60,7 @@ class DropDown extends Component {
 
 export default ({ choices, currentFilter, handleFilter }) => {
   return (
-    <ul className="current-filter-list">
+    <ul className="current-filter-list" css={{ marginLeft: 0 }}>
       <Global
         styles={css`
           .arrow-down {

--- a/src/components/peopleVote.js
+++ b/src/components/peopleVote.js
@@ -53,7 +53,7 @@ const PeopleVoteCard = ({ choice, fields, title, legal_title, vote_date }) => (
   >
     <div
       css={{
-        color: voteColor[choice],
+        color: choice === "3" ? "var(--cl-black)" : voteColor[choice],
         margin: "15px 0px",
         fontSize: "2.4rem",
       }}

--- a/src/components/peopleVote.js
+++ b/src/components/peopleVote.js
@@ -19,9 +19,9 @@ const filterChoice = [
 ]
 
 const voteColor = {
-  "1": "#329a2e",
-  "2": "#ec2627",
-  "3": "#aaaaaa",
+  "1": "var(--cl-vote-yes)",
+  "2": "var(--cl-vote-no)",
+  "3": "var(--cl-vote-abstained)",
   "4": "#272727",
   "": "-",
 }

--- a/src/components/waffle.css
+++ b/src/components/waffle.css
@@ -2,13 +2,13 @@
   display: flex;
   flex-wrap: wrap;
   width: 950px;
-  height: 348px;
+  height: 256px;
 }
 
 .line {
   background-color: black;
   width: 2px;
-  height: 324px;
+  height: 256px;
   margin: 0 3rem 0 0;
 }
 
@@ -17,7 +17,7 @@
   flex-wrap: wrap;
   align-content: flex-start;
   width: 55px;
-  height: 348px;
+  height: 256px;
   margin: 0 27px 0 0;
 }
 
@@ -27,7 +27,11 @@
   align-content: flex-start;
   width: 55px;
   height: 55px;
-  margin: 0 0 9px 0;
+  margin: 0 0 12px 0;
+}
+
+.quarter:last-child {
+  margin: 0;
 }
 
 @media only screen and (max-width: 950px) {
@@ -39,16 +43,21 @@
   .line {
     width: 333px;
     height: 2px;
-    margin: 0 0 3rem;
+    margin: 0;
   }
 
   .hundred {
     flex-wrap: nowrap;
-    width: 348px;
-    height: 75px;
+    width: 256px;
+    height: 55px;
+    margin: 0;
   }
 
   .quarter {
     margin: 0 12px 0 0;
+  }
+
+  .quarter:last-child {
+    margin: 0;
   }
 }

--- a/src/components/waffle.js
+++ b/src/components/waffle.js
@@ -89,7 +89,14 @@ const waffle = (data, color, borderColor, add_separator) => {
 }
 
 const Waffle = ({ data, colors, borderColors, style, css }) => (
-  <div className="waffle" css={css} style={style}>
+  <div
+    className="waffle"
+    css={{
+      justifyContent: "center",
+      ...css,
+    }}
+    style={style}
+  >
     {data.map((group, group_idx) =>
       waffle(
         group,

--- a/src/components/waffleFilter.js
+++ b/src/components/waffleFilter.js
@@ -132,7 +132,14 @@ class WaffleFilter extends Component {
             }`}
           </span>
         </h2>
-        <div css={{ margin: "50px auto 0 auto" }}>
+        <div
+          css={{
+            margin: "50px auto 0 auto",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
           <Dropdown
             choices={this.props.choices}
             currentFilter={this.state.currentFilter}
@@ -142,7 +149,6 @@ class WaffleFilter extends Component {
             data={[this.state.data_of_interest, this.state.data_the_rest]}
             colors={[`var(--cl-pink)`, `var(--cl-gray-3)`]}
             borderColors={[`var(--cl-pink)`, `var(--cl-gray-3)`]}
-            style={{ justifyContent: "center" }}
           />
         </div>
       </>

--- a/src/pages/cabinet.js
+++ b/src/pages/cabinet.js
@@ -171,7 +171,9 @@ const CabinetPage = props => {
 
       <section className="section" css={{ background: "var(--cl-white)" }}>
         <h1 css={{ fontSize: "4.8rem", textAlign: "center" }}>สมาชิกทั้งหมด</h1>
-        <CabinetMemberSection />
+        <div className="container">
+          <CabinetMemberSection />
+        </div>
       </section>
     </Layout>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -192,7 +192,23 @@ const IndexPage = ({ data }) => {
             <Hero />
 
             <div css={{ textAlign: "center" }}>
-              <Button to="/about">เกี่ยวกับเรา</Button>
+              <Link
+                to="/about"
+                css={{
+                  padding: "1rem 4rem",
+                  fontFamily: "var(--ff-title)",
+                  fontSize: "2.4rem",
+                  color: "var(--cc-white)",
+                  textDecoration: "underline",
+                  border: "none",
+                  background: "none",
+                  "&:hover": {
+                    color: "gray",
+                  },
+                }}
+              >
+                เกี่ยวกับเรา
+              </Link>
             </div>
           </div>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,8 +17,8 @@
   --cl-gray-3: #cccccc;
   --cl-gray-4: #eeeeee;
 
-  --cl-vote-yes: #329a2e;
-  --cl-vote-no: #ec2627;
+  --cl-vote-yes: #74b5b2;
+  --cl-vote-no: #f0324b;
   --cl-vote-abstained: #cccccc;
   --cl-vote-absent: #ffffff;
 

--- a/src/templates/votelog-template.js
+++ b/src/templates/votelog-template.js
@@ -246,7 +246,14 @@ const VotelogPage = ({
           </span>
         </span>
       </section>
-      <section css={cssSection}>
+      <section
+        css={{
+          display: "flex",
+          alignItems: "center",
+          flexDirection: "column",
+          ...cssSection,
+        }}
+      >
         <Waffle
           data={[
             approve.map(p => ({ node: p })),
@@ -267,7 +274,7 @@ const VotelogPage = ({
             `var(--cl-black)`,
           ]}
         />
-        <div>
+        <div css={{ marginTop: "4rem" }}>
           <VoteLogLegend {...votelogYaml} />
         </div>
       </section>


### PR DESCRIPTION
## Description
### From Feedback
- Make `<Waffle>` displays center in mobile
- Change vote-yes and vote-no colors for color-blind inclusiveness
- Update about button in index with more subtle style
### Bug
- Fix cabinet members display outside container area

## Screenshot
### Waffle
#### Index
![Screenshot_2019-11-28 They Work For Us รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา](https://user-images.githubusercontent.com/6439183/69754184-df219a80-1187-11ea-9f7a-c8819bc334d6.png)

#### Votelog
![Screenshot_2019-11-28 ตั้งคณะกรรมาธิการวิสามัญพิจารณาผลกระทบโครงการอีอีซี](https://user-images.githubusercontent.com/6439183/69754186-e0eb5e00-1187-11ea-9aa8-d76f42176dc1.png)

### Color-blind Inclusiveness
![Screenshot_2019-11-28 They Work For Us รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา(2)](https://user-images.githubusercontent.com/6439183/69754228-f9f40f00-1187-11ea-8c6a-6b076eb9d94b.png)


(Also small change for "งดออกเสียง" label's color to be black)
![Screenshot_2019-11-28 นางสาว ศรีนวล บุญลือ](https://user-images.githubusercontent.com/6439183/69754231-fc566900-1187-11ea-8fed-ae0f4ea04ebd.png)

### About Button
![Screenshot_2019-11-28 They Work For Us รู้จักและติดตาม 'ผู้แทน' ในสภาของเรา(1)](https://user-images.githubusercontent.com/6439183/69754262-1132fc80-1188-11ea-8e48-112c59ffea7a.png)

### Cabinet Members
![Screenshot_2019-11-28 คณะรัฐมนตรี](https://user-images.githubusercontent.com/6439183/69754195-e9439900-1187-11ea-83aa-78d2b4110bfc.png)
